### PR TITLE
Ensure trailing slash for customize-preview-js src

### DIFF
--- a/classes/styles-customize.php
+++ b/classes/styles-customize.php
@@ -40,7 +40,7 @@ class Styles_Customize {
 		// Version set to md5 of settings because JS generated from settings
 		$custom_preview_version = md5( serialize( $this->settings ) );
 
-		$custom_preview_url = add_query_arg( 'styles-action', 'customize-preview-js', site_url() );
+		$custom_preview_url = add_query_arg( 'styles-action', 'customize-preview-js', site_url( '/' ) );
 		
 		// Account for theme previews
 		$custom_preview_url = add_query_arg( 'theme', Styles_Helpers::get_template(), $custom_preview_url );


### PR DESCRIPTION
On a multisite subdirectory install, for a site 'foo', a URL like the following results in a `NOBLOGREDIRECT`:

http://example.com/foo?styles-action=customize-preview-js...

This results in the preview not working at all. The fix is to ensure that the script path ends in a slash, and this helps WordPress Multisite properly route the request to the current site:

http://example.com/foo/?styles-action=customize-preview-js...
